### PR TITLE
11 model and controller are getting too big

### DIFF
--- a/Controller.py
+++ b/Controller.py
@@ -1,5 +1,4 @@
 from Models.Model import Model
-from Models import DataObjects
 from Views.View import View
 
 
@@ -39,11 +38,22 @@ class Controller:
                 item["widget"].update_field(item["field"], new_value)
 
     def register_field(self, field, obj):
+        """
+        Fields with access to the controller can call this function to register themselves, to be notified if any
+        widgets from the view try to update that field. The passed field must have a method named
+        'update_field(field, new_value)'
+        """
         to_register = {"field": field,
                        "object": obj}
         self.registered_fields.append(to_register)
 
     def trigger_field(self, field, new_value):
+        """
+        Called by a widget when it changes some data. The widget provides the field name that was changed and the
+        new value of that filed. This function then looks at all the registered fields from the model, to see if they
+        have requested that field. If it has, it gives the field the new value.
+        The field can do whatever with that knowledge.
+        """
         for item in self.registered_fields:
             if item["field"] == field:
                 item["object"].update_field(item["field"], new_value)
@@ -53,15 +63,6 @@ class Controller:
 
     def race_entered(self, race_choice):
         self.model.set_race(race_choice)
-
-    def ability_entered(self, ability, new_value):
-        self.model.set_ability(ability, new_value)
-
-    def proficiency_entered(self, action, skill):
-        if action == "add":
-            self.model.add_skill_proficiency(skill)
-        if action == "remove":
-            self.model.remove_skill_proficiency(skill)
 
     def get_ability_list(self):
         return list(self.model.character.ability_scores)
@@ -73,7 +74,7 @@ class Controller:
         return skills
 
     def get_related_ability(self, skill):
-        return DataObjects.skill_to_score_map(skill)
+        return self.model.skill_to_score_map.get(skill)
 
     def get_class_names(self):
         names = []

--- a/Controller.py
+++ b/Controller.py
@@ -6,6 +6,7 @@ from Views.View import View
 class Controller:
     def __init__(self, window):
         self.registered_widgets = []
+        self.registered_fields = []
 
         self.model = Model(self)
         self.view = View(window, self)
@@ -17,34 +18,35 @@ class Controller:
         self.view.show_character_page()
         self.model.load_character("New_Character")
 
-    def register(self, widget, field):
+    def register_widget(self, widget, field):
         """
         Widgets with access to the controller can call this function to register themselves, or a widget they own, to be
         notified if the specified field is updated in the model. The passed widget must have a method named
         'update_field(field, new_value)'
-        :param widget:
-        :param field:
-        :return:
         """
         to_register = {"widget": widget,
                        "field": field}
         self.registered_widgets.append(to_register)
 
-    def triggered(self, field, new_value):
+    def trigger_widget(self, field, new_value):
         """
         Called by the model when it changes some data. the model provides the field name that was changed and the
         new value of that filed. This function then looks at all the registered widgets, to see if they have requested
         that field. If it has, it gives the widget the new value. The widget can do whatever with that knowledge.
-        :param field:
-        :param new_value:
-        :return:
         """
         for item in self.registered_widgets:
             if item["field"] == field:
                 item["widget"].update_field(item["field"], new_value)
 
-    def name_entered(self, name):
-        self.model.set_name(name)
+    def register_field(self, field, obj):
+        to_register = {"field": field,
+                       "object": obj}
+        self.registered_fields.append(to_register)
+
+    def trigger_field(self, field, new_value):
+        for item in self.registered_fields:
+            if item["field"] == field:
+                item["object"].update_field(item["field"], new_value)
 
     def class_entered(self, class_choice):
         self.model.set_class(class_choice)

--- a/Models/Character.py
+++ b/Models/Character.py
@@ -1,14 +1,18 @@
 # This will be the class that holds information on the Player Character as they enter information
+from Models import DataObjects
+
 
 class CharacterData:
-    def __init__(self, controller):
+    def __init__(self, controller, scoremap):
         self.controller = controller
+        self.skill_to_score_map = scoremap
 
         self.name = ""
-        self.level = None
-        self.proficiency_bonus = None
-        self.claas = None
-        self.race = None
+        self.level = ""
+        self.proficiency_bonus = ""
+        self.claas = ""
+        self.race = ""
+        self.strength_score = ""
 
         self.ability_scores = {
             "Strength": "",
@@ -59,12 +63,76 @@ class CharacterData:
         }
 
     def __dir__(self):
-        return ["name", "level", "proficiency_bonus", "claas", "race", "ability_scores", "ability_modifiers",
-                "skill_proficiencies", "skill_bonuses"]
+        return ["name", "level", "proficiency_bonus", "claas", "race", "Strength_score", "score",
+                "ability_modifiers", "skill_proficiencies", "skill_bonuses"]
 
     def update_field(self, field, new_value):
-        getattr(self, "set_" + field)(new_value)
+        try:
+            print("Calling", "set_"+field, "with ", new_value)
+            getattr(self, "set_" + field)(new_value)
+        except AttributeError:
+            print("No function found in Character for set_" + field)
 
     def set_name(self, new_name):
         self.name = new_name
         self.controller.trigger_widget("name", self.name)
+
+    def set_score(self, value_details):
+        ability = value_details[0]
+        new_score = value_details[1]
+        self.ability_scores[ability] = new_score
+        self.controller.trigger_widget(ability, new_score)
+
+        self.set_modifier(ability)
+        self.set_skill_bonus(ability)
+
+    def set_modifier(self, ability):
+        if self.ability_scores[ability] == "":  # If the new ability score is empty
+            self.ability_modifiers[ability] = ""
+        else:
+            # Calculate the modifier
+            modifier = int(self.ability_scores[ability]) - 10
+            # Update the modifier
+            if modifier < 0:  # This accounts for dividing by negative numbers
+                self.ability_modifiers[ability] = str(int((modifier - 1) / 2))
+            else:
+                self.ability_modifiers[ability] = str(int(modifier / 2))
+
+        self.controller.trigger_widget(ability + "_mod", self.ability_modifiers[ability])
+
+    def set_skill_bonus(self, ability):
+        modifier = self.ability_modifiers[ability]
+        # If the ability value, and the related modifier is empty, no math is done
+        if modifier == "" or modifier is None:
+            mod_with_proficiency = ""
+        else:  # If not empty, consider the proficiency bonus
+            mod_with_proficiency = str(int(modifier) + int(self.proficiency_bonus))
+
+        related_skills = DataObjects.score_to_skill_dict(ability)
+
+        # Place modifier for the saving throw
+        if self.skill_proficiencies.count(ability) != 0:  # If proficient with save
+            self.skill_bonuses[ability] = mod_with_proficiency  # Update with modifier + proficiency
+        else:  # if not proficient with the save
+            self.skill_bonuses[ability] = modifier  # Update with modifier
+        # Announce the save was updated
+        self.controller.trigger_widget(ability + "_skill", self.skill_bonuses[ability])
+
+        # Repeat that, but with each related skill for the ability score
+        for skill in related_skills:
+            if self.skill_proficiencies.count(skill) != 0:  # If proficient with skill
+                self.skill_bonuses[skill] = mod_with_proficiency  # Update with modifier + proficiency
+            else:  # if not proficient with the skill
+                self.skill_bonuses[skill] = modifier  # Update with modifier
+            # Announce the skill was updated
+            self.controller.trigger_widget(skill + "_skill", self.skill_bonuses[skill])
+
+    def set_skill_proficiencies(self, value_details):
+        if value_details[0] == 'add':
+            related_ability = self.skill_to_score_map.get(value_details[1])
+            self.skill_proficiencies.append(value_details[1])
+            self.set_skill_bonus(related_ability)
+        elif value_details[0] == 'remove':
+            related_ability = self.skill_to_score_map.get(value_details[1])
+            self.skill_proficiencies.remove(value_details[1])
+            self.set_skill_bonus(related_ability)

--- a/Models/Character.py
+++ b/Models/Character.py
@@ -1,7 +1,9 @@
 # This will be the class that holds information on the Player Character as they enter information
 
 class CharacterData:
-    def __init__(self):
+    def __init__(self, controller):
+        self.controller = controller
+
         self.name = ""
         self.level = None
         self.proficiency_bonus = None
@@ -55,3 +57,14 @@ class CharacterData:
             "Stealth": "0",
             "Survival": "0"
         }
+
+    def __dir__(self):
+        return ["name", "level", "proficiency_bonus", "claas", "race", "ability_scores", "ability_modifiers",
+                "skill_proficiencies", "skill_bonuses"]
+
+    def update_field(self, field, new_value):
+        getattr(self, "set_" + field)(new_value)
+
+    def set_name(self, new_name):
+        self.name = new_name
+        self.controller.trigger_widget("name", self.name)

--- a/Models/DataObjects.py
+++ b/Models/DataObjects.py
@@ -11,7 +11,7 @@ def ability_skills():
     return skills
 
 
-def skill_to_score_map(skill):
+def skill_to_score_map():
     score_map = {
         "Strength": "Strength",
         "Dexterity": "Dexterity",
@@ -39,7 +39,7 @@ def skill_to_score_map(skill):
         "Stealth": "Dexterity",
         "Survival": "Wisdom"
     }
-    return score_map[skill]
+    return score_map
 
 
 def score_to_skill_dict(ability):

--- a/Models/Model.py
+++ b/Models/Model.py
@@ -10,8 +10,9 @@ class Model:
     def __init__(self, controller):
         self.controller = controller
         self.databaseAPI = DatabaseAPI()
+        self.skill_to_score_map = DataObjects.skill_to_score_map()
 
-        self.character = Character.CharacterData(self.controller)
+        self.character = Character.CharacterData(self.controller, self.skill_to_score_map)
 
         # Create empty dictionaries
         self.class_options = {}
@@ -22,6 +23,7 @@ class Model:
         self.load_races()
         self.load_armors()
 
+        # Create directory/registry to be called by the controller
         self.directory = {}
         self.create_directory()
         self.register_fields()
@@ -40,19 +42,18 @@ class Model:
         # Load character by name, returns a dict. Keys match the DB table columns
         character_data = self.databaseAPI.load_character(character_name)
 
-        #self.set_name(character_data["Name"])
         self.character.set_name(character_data["Name"])
         self.set_level(character_data["Level"])  # set_level also sets the proficiency bonus
         self.set_class(character_data["Class"])
         self.set_race(character_data["Race"])
 
         # Each set_ability also sets the ability modifiers and skill bonuses
-        self.set_ability("Strength", character_data["Strength Score"])
-        self.set_ability("Dexterity", character_data["Dexterity Score"])
-        self.set_ability("Constitution", character_data["Constitution Score"])
-        self.set_ability("Intelligence", character_data["Intelligence Score"])
-        self.set_ability("Wisdom", character_data["Wisdom Score"])
-        self.set_ability("Charisma", character_data["Charisma Score"])
+        self.character.set_score(["Strength", character_data["Strength Score"]])
+        self.character.set_score(["Dexterity", character_data["Dexterity Score"]])
+        self.character.set_score(["Constitution", character_data["Constitution Score"]])
+        self.character.set_score(["Intelligence", character_data["Intelligence Score"]])
+        self.character.set_score(["Wisdom", character_data["Wisdom Score"]])
+        self.character.set_score(["Charisma", character_data["Charisma Score"]])
 
     def call_registered(self, field, new_value):
         self.controller.trigger_widget(field, new_value)
@@ -76,66 +77,6 @@ class Model:
     def set_proficiency_bonus(self):
         self.character.proficiency_bonus = DataObjects.proficiency_bonus_map(self.character.level)
         self.controller.trigger_widget("proficiency_bonus", self.character.proficiency_bonus)
-
-    def set_ability(self, ability, new_value):
-        self.character.ability_scores[ability] = new_value
-        self.call_registered(ability, new_value)
-
-        self.set_modifier(ability)
-        self.set_skill_bonus(ability)
-
-    def set_modifier(self, ability):
-        if self.character.ability_scores[ability] == "":  # If the new ability score is empty
-            self.character.ability_modifiers[ability] = ""
-        else:
-            # Calculate the modifier
-            modifier = int(self.character.ability_scores[ability]) - 10
-            # Update the modifier
-            if modifier < 0:  # This accounts for dividing by negative numbers
-                self.character.ability_modifiers[ability] = str(int((modifier - 1) / 2))
-            else:
-                self.character.ability_modifiers[ability] = str(int(modifier / 2))
-
-        self.call_registered(ability + "_mod", self.character.ability_modifiers[ability])
-
-    def set_skill_bonus(self, ability):
-        modifier = self.character.ability_modifiers[ability]
-        # If the ability value, and the related modifier is empty, no math is done
-        if modifier == "" or modifier is None:
-            mod_with_proficiency = ""
-        else:  # If not empty, consider the proficiency bonus
-            mod_with_proficiency = str(int(modifier) + int(self.character.proficiency_bonus))
-
-        related_skills = DataObjects.score_to_skill_dict(ability)
-
-        # Place modifier for the saving throw
-        if self.character.skill_proficiencies.count(ability) != 0:  # If proficient with save
-            self.character.skill_bonuses[ability] = mod_with_proficiency  # Update with modifier + proficiency
-        else:  # if not proficient with the save
-            self.character.skill_bonuses[ability] = modifier  # Update with modifier
-        # Announce the save was updated
-        self.call_registered(ability + "_skill", self.character.skill_bonuses[ability])
-
-        # Repeat that, but with each related skill for the ability score
-        for skill in related_skills:
-            if self.character.skill_proficiencies.count(skill) != 0:  # If proficient with skill
-                self.character.skill_bonuses[skill] = mod_with_proficiency  # Update with modifier + proficiency
-            else:  # if not proficient with the skill
-                self.character.skill_bonuses[skill] = modifier  # Update with modifier
-            # Announce the skill was updated
-            self.call_registered(skill + "_skill", self.character.skill_bonuses[skill])
-
-    def add_skill_proficiency(self, skill):
-        related_ability = DataObjects.skill_to_score_map(skill)
-        self.character.skill_proficiencies.append(skill)
-        self.set_skill_bonus(related_ability)
-        # Does not call any registered fields
-
-    def remove_skill_proficiency(self, skill):
-        related_ability = DataObjects.skill_to_score_map(skill)
-        self.character.skill_proficiencies.remove(skill)
-        self.set_skill_bonus(related_ability)
-        # Does not call any registered fields
 
     def load_classes(self):
         classes = self.databaseAPI.load_classes()

--- a/Views/CustomObjects.py
+++ b/Views/CustomObjects.py
@@ -47,7 +47,7 @@ class AbilityBox(ttk.Frame):
 
     def ability_updated(self, *args):
         # Let the controller know that the ability score was updated
-        self.controller.ability_entered(self.ability, self.ability_score.get())
+        self.controller.trigger_field("score", [self.ability, self.ability_score.get()])
 
     def update_field(self, field, new_value):
         if field == self.ability + "_mod":
@@ -85,9 +85,9 @@ class SkillLine(ttk.Frame):
 
     def update_proficiency(self):
         if self.ckbtn_proficient.instate(['selected']):  # When selected, add proficiency
-            self.controller.proficiency_entered('add', self.skill)
+            self.controller.trigger_field('skill_proficiencies', ['add', self.skill])
         else:
-            self.controller.proficiency_entered('remove', self.skill)
+            self.controller.trigger_field('skill_proficiencies', ['remove', self.skill])
 
 
 class ProfBonusBox(ttk.Frame):

--- a/Views/CustomObjects.py
+++ b/Views/CustomObjects.py
@@ -43,7 +43,7 @@ class AbilityBox(ttk.Frame):
         self.lbl_modifier.grid(column=0, row=2)
 
         # Register with the controller, to be notified if the ability modifier is updated
-        self.controller.register(self, self.ability + "_mod")
+        self.controller.register_widget(self, self.ability + "_mod")
 
     def ability_updated(self, *args):
         # Let the controller know that the ability score was updated
@@ -77,7 +77,7 @@ class SkillLine(ttk.Frame):
         self.lbl_skill.grid(column=1, row=0)
 
         # Register with the controller, to be notified if the related ability modifier gets updated
-        self.controller.register(self, self.skill + "_skill")
+        self.controller.register_widget(self, self.skill + "_skill")
 
     def update_field(self, field, new_val):
         if field == self.skill + "_skill":
@@ -103,7 +103,7 @@ class ProfBonusBox(ttk.Frame):
         self.lbl_bonus.grid(column=0, row=0)
         self.lbl_proficiency.grid(column=1, row=0)
 
-        self.controller.register(self, "proficiency_bonus")
+        self.controller.register_widget(self, "proficiency_bonus")
 
     def update_field(self, field, new_val):
         if field == "proficiency_bonus":
@@ -124,7 +124,7 @@ class PassiveSkillBox(ttk.Frame):
         self.lbl_bonus.grid(column=0, row=0)
         self.lbl_skill.grid(column=1, row=0)
 
-        self.controller.register(self, self.skill + "_skill")
+        self.controller.register_widget(self, self.skill + "_skill")
 
     def update_field(self, field, new_val):
         if field == self.skill + "_skill":
@@ -149,11 +149,11 @@ class CharacterNameBox(ttk.Frame):
         self.ent_name.grid(column=0, row=0)
         self.lbl_label.grid(column=0, row=1)
 
-        self.controller.register(self, "name")
+        self.controller.register_widget(self, "name")
 
     def name_entered(self, *args):
-        # Called by changes to ent_name
-        self.controller.name_entered(self.name.get())
+        # Tell the controller this field changed
+        self.controller.trigger_field("name", self.name.get())
 
     def update_field(self, field, new_val):
         # Called by the controller, since self is registered
@@ -179,7 +179,7 @@ class LabeledOptions(ttk.Frame):
         self.label.grid(column=0, row=1)
 
         self.cbox_optionsList.bind("<<ComboboxSelected>>", self.option_selected)
-        self.controller.register(self, self.title)
+        self.controller.register_widget(self, self.title)
 
     def option_selected(self, *args):
         if self.title == "class":
@@ -224,8 +224,7 @@ class HitDieBox(ttk.Frame):
         self.lbl_die.grid(column=0, row=0)
         self.lbl_description.grid(column=0, row=1)
 
-        self.controller.register(self, "class")
-
+        self.controller.register_widget(self, "class")
 
     def update_field(self, field, new_value):
         if field == "class":
@@ -254,7 +253,7 @@ class ArmorProficiencies(ttk.Frame):
         rb_heavy.grid(column=2, row=1)
         rb_shield.grid(column=3, row=1)
 
-        self.controller.register(self, "class")
+        self.controller.register_widget(self, "class")
 
     def update_field(self, field, new_value):
         if field == "class":
@@ -299,7 +298,7 @@ class WeaponProficiencies(ttk.Frame):
         rb_martial.grid(column=1, row=1)
         # lbl_other gets .grid when fields are updated
 
-        self.controller.register(self, "class")
+        self.controller.register_widget(self, "class")
 
     def update_field(self, field, new_value):
         if field == "class":
@@ -338,9 +337,9 @@ class ListProficiencies(ttk.Frame):
         ttk.Label(self.items_frame, text="None").grid(column=0, row=0)
 
         if self.description == "Tool Proficiencies":
-            self.controller.register(self, "class")
+            self.controller.register_widget(self, "class")
         if self.description == "Language Proficiencies":
-            self.controller.register(self, "race")
+            self.controller.register_widget(self, "race")
 
     def update_field(self, field, new_value):
         if field == "class":


### PR DESCRIPTION
Now when a widget needs to update a field, it does not call a related function from the controller to do so. All widgets call controller.trigger_field to make an update. The model is currently registering all fields in objects it holds with the controller for this to happen.
Currently, the controller calls the related object directly, this should be moved to a model function. The controller shouldn't know about particular objects.
With this optimization, objects now own their update functions, rather than the model having them for each object. I was able to remove a function from the controller and object for each case.